### PR TITLE
Malformed URL and encoding of percentage

### DIFF
--- a/dev/src/hasher.js
+++ b/dev/src/hasher.js
@@ -296,7 +296,7 @@ var hasher = (function(window){
         setHash : function(path){
             path = _makePath.apply(null, arguments);
             if(path !== _hash){
-                _registerChange(path); //avoid breaking the application if for some reason `window.location.hash` don't change
+                _registerChange(encodeURI(path)); //avoid breaking the application if for some reason `window.location.hash` don't change
                 window.location.hash = '#'+ encodeURI(path); //used encodeURI instead of encodeURIComponent to preserve '?', '/', '#'. Fixes Safari bug [issue #8]
             }
         },
@@ -312,7 +312,7 @@ var hasher = (function(window){
         replaceHash : function(path){
             path = _makePath.apply(null, arguments);
             if(path !== _hash){
-                _registerChange(path, true);
+                _registerChange(encodeURI(path), true);
                 window.location.replace('#'+ encodeURI(path));
             }
         },

--- a/dev/tests/unit/01.js
+++ b/dev/tests/unit/01.js
@@ -360,7 +360,7 @@ module();
 test('multiple listeners & changes', function (){
 
     stop(2000);
-    expect(25);
+    expect(29);
 
     function handler1(evt){
         ok(true, 'Called Handler #1');
@@ -397,6 +397,8 @@ test('multiple listeners & changes', function (){
     hasher.setHash('Lorem/Dolor&Amet/?foo=bar&ipsum=dolor&n=123&nan=abc123');
     equals(hasher.getHash(), 'Lorem/Dolor&Amet/?foo=bar&ipsum=dolor&n=123&nan=abc123');
 
+    hasher.setHash('something%');
+    equals(hasher.getHash(), 'something%');
 
     hasher.setHash('?foo=bar&ipsum=dolor');
     equals(hasher.getHash(), '?foo=bar&ipsum=dolor');


### PR DESCRIPTION
`_registerChange` expects the `newHash` parameter to be encoded, but some internal calls did not encode values passed to it. This fixes the '%' encoding, and the resulting Malformed URL exception.

The fix has been tested in IE8, IE9, latest Firefox and Chrome. I've added a unit test that tests for this case. Before this patch the unit test fails, and when applied it succeeds.
