### PR TITLE
Correction of 'define' invocation

### DIFF
--- a/dev/src/wrapper.js
+++ b/dev/src/wrapper.js
@@ -1,6 +1,6 @@
 //::LICENSE:://
 (function (define) {
-    define('hasher', ['signals'], function(signals){
+    define(['signals'], function(signals){
 
 //::HASHER:://
 

--- a/dev/src/wrapper.js
+++ b/dev/src/wrapper.js
@@ -6,6 +6,6 @@
 
         return hasher;
     });
-}(typeof define === 'function' && define.amd ? define : function (id, deps, factory) {
-    window[id] = factory(window[deps[0]]);
+}(typeof define === 'function' && define.amd ? define : function (deps, factory) {
+    window.hasher = factory(window[deps[0]]);
 }));


### PR DESCRIPTION
Defining a module with a name (a string as first argument to define()) causes problems when the directory structure is different from the name given (i.e. when the project using Hasher has it placed e.g. in `/3rdparty/hasher.js`). Defining it as an anonymous module  (AMD) is problem-free. For that reason, it makes sense to remove the name from wrapper.js' define statement, as I have done here.

"You may encounter some define() calls that include a name for the module as the first argument to define()[...] These are normally generated by the optimization tool. [...] It is normally best to avoid coding in a name for the module and just let the optimization tool burn in the module names."
- http://requirejs.org/docs/api.html#modulename
