### PR TITLE
Using hasher with already percent-encoded strings - pull request

### DIFF
--- a/dev/src/hasher.js
+++ b/dev/src/hasher.js
@@ -68,7 +68,11 @@ var hasher = (function(window){
         //parsed full URL instead of getting window.location.hash because Firefox decode hash value (and all the other browsers don't)
         //also because of IE8 bug with hash query in local file [issue #6]
         var result = _hashValRegexp.exec( hasher.getURL() );
-        return (result && result[1])? decodeURIComponent(result[1]) : '';
+        if (hasher.raw) {
+            return (result && result[1])? result[1] : '';
+        } else {
+            return (result && result[1])? decodeURIComponent(result[1]) : '';
+        }
     }
 
     function _getFrameHash(){
@@ -334,7 +338,12 @@ var hasher = (function(window){
                 if (path === _hash) {
                     // we check if path is still === _hash to avoid error in
                     // case of multiple consecutive redirects [issue #39]
-                    window.location.hash = '#' + _encodePath(path);
+                    if (hasher.raw) {
+                        window.location.hash = '#' + path;
+                    } else {
+                        window.location.hash = '#' + _encodePath(path);
+                    }
+
                 }
             }
         },
@@ -355,7 +364,11 @@ var hasher = (function(window){
                 if (path === _hash) {
                     // we check if path is still === _hash to avoid error in
                     // case of multiple consecutive redirects [issue #39]
-                    window.location.replace('#' + _encodePath(path));
+                    if (hasher.raw) {
+                        window.location.replace('#' + path);
+                    } else {
+                        window.location.replace('#' + _encodePath(path));
+                    }
                 }
             }
         },

--- a/dev/src/hasher.js
+++ b/dev/src/hasher.js
@@ -188,6 +188,15 @@ var hasher = (function(window){
         VERSION : '::VERSION_NUMBER::',
 
         /**
+         * Boolean deciding if hasher encodes/decodes the hash or not.
+         * <ul>
+         * <li>default value: false;</li>
+         * </ul>
+         * @type boolean
+         */
+        raw : false,
+
+        /**
          * String that should always be added to the end of Hash value.
          * <ul>
          * <li>default value: '';</li>

--- a/dev/tests/unit/01.js
+++ b/dev/tests/unit/01.js
@@ -689,7 +689,44 @@ test('appendHash + $ [issue #49]', function(){
 
 });
 
+/* ==== raw hashes ==== */
 
+module();
+
+test('raw hashes', function (){
+    stop(500);
+
+    hasher.raw = true;
+
+    hasher.init();
+
+    var hashChangeHandler = function(newHash, oldHash){
+        ok(newHash !== oldHash, 'hash changed');
+        equals(newHash, 'foo%20bar', 'new hash');
+    };
+
+    hasher.changed.add(hashChangeHandler);
+
+    hasher.appendHash = '';
+    hasher.setHash('foo%20bar');
+
+
+    setTimeout(function(){
+        hasher.changed.remove(hashChangeHandler);
+
+        hasher.changed.add(function(newHash, oldHash){
+            equals(newHash, 'foo%20lorem%3Damet', 'new hash');
+            equals(oldHash, 'foo%20bar', 'old hash');
+            hasher.changed.removeAll();
+            start();
+        });
+
+        setTimeout(function(){
+            hasher.setHash('foo%20lorem%3Damet');
+        }, DELAY_BACK_FORWARD);
+
+    }, DELAY_BACK_FORWARD);
+});
 
 /* ==== dispose ==== */
 


### PR DESCRIPTION
Hi,

Based on the discussion in https://github.com/millermedeiros/Hasher/issues/56 I've come up with a strategy for using Hasher with already percent-encoded strings. 

Rather than exposing this as separate functions on the API, it seemed more logical to use a boolean config option to toggle encode/decode, as otherwise a great deal of functions would have to be duplicated and the inner workings would need much more special-casing (setHash is also called internally).

I've added some passing tests as well, which might have to be expanded a bit but at least show that the code changes function.

Hope you like these changes. Have a nice day!

/maarten
